### PR TITLE
Update Renovate configuration

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -3,5 +3,35 @@
   "extends": [
     "config:base"
   ],
-  "baseBranches": ["dev"]
+  "baseBranches": [
+    "dev"
+  ],
+  "packageRules": [
+    {
+      "matchUpdateTypes": [
+        "patch"
+      ],
+      "automerge": true,
+      "automergeType": "branch",
+      "groupName": "patch",
+      "schedule": [
+        "after 10pm and before 6:00am every day"
+      ]
+    },
+    {
+      "matchUpdateTypes": [
+        "minor"
+      ],
+      "automerge": false,
+      "schedule": [
+        "before 6:00am every friday"
+      ]
+    }
+  ],
+  "vulnerabilityAlerts": {
+    "labels": [
+      "Component::security"
+    ],
+    "automerge": true
+  }
 }


### PR DESCRIPTION
The Renovate configuration can automate the merging of pull requests. Currently, the bot merges every dependency update as soon as it’s created, even if the update is just a patch. This approach reduces the overall maintainability of the project