### PR TITLE
Add templates for issues, pull requests and more

### DIFF
--- a/.github/ISSUE_TEMPLATES/behavior-bug.yml
+++ b/.github/ISSUE_TEMPLATES/behavior-bug.yml
@@ -1,0 +1,58 @@
+name: Behavior Bug
+description: Report issues with the given `BlockHandler` implementations or other behavior bugs
+title: "[Bug]: "
+labels: [ "status: needs triage", "type: bug" ]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thank you for reporting a bug to Canis!
+        Please fill out the information below to help us understand the issue.
+  - type: markdown
+    attributes:
+      value: |
+        Before filling the form fields, please consider the following:
+        - Search for existing issues in the [issue tracker](https://github.com/theEvilReaper/Canis/issues)
+  - type: input
+    attributes:
+      label: Canis version
+      description: Please enter the version of Canis you are using.
+      placeholder: 1.0.0
+    validations:
+      required: false
+  - type: textarea
+    attributes:
+      label: Describe the bug
+      description: |
+        A clear and concise description of what the bug is.
+        If you have a screenshot of the bug, please attach it below.
+    validations:
+      required: true
+  - type: textarea
+    attributes:
+      label: Steps to reproduce the bug
+      description: Tell us exactly how to reproduce the bug you are experiencing
+      placeholder: |
+        1. ...
+        2. ...
+        3. ...
+    validations:
+      required: true
+  - type: textarea
+    attributes:
+      label: Code sample
+      description: |
+        Please create a reproducible sample to show us the bug in action and attach it below between the lines with the backticks.
+        This helps us to verify that the bug is valid and prevents us from having to ask you for a sample later.
+        
+        Without this we will unlikely be able to progress on the issue, and because of that
+        we regretfully will have to close it.
+        
+        **Note**: Please do not upload screenshots of text. Instead, use code blocks
+        or the above mentioned ways to upload your code sample.
+      value: |
+        ```java
+        [Paste your code here]
+        ```
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATES/config.yml
+++ b/.github/ISSUE_TEMPLATES/config.yml
@@ -1,0 +1,6 @@
+blank_issues_enabled: false
+contact_links:
+  - name: General discussions for Canis
+    url: https://github.com/theEvilReaper/Canis/discussions
+    about: If you have any questions or problems, please use the discussions section
+    emoji: ❓

--- a/.github/ISSUE_TEMPLATES/feature-request.yml
+++ b/.github/ISSUE_TEMPLATES/feature-request.yml
@@ -6,8 +6,8 @@ body:
   - type: markdown
     attributes:
       value: |
-        Thank you for filling out a feature request for Canis! Please be as detailed as possible so that we may consider and review the request easier.
-        We ask that you search all the issues to avoid a duplicate feature request. If one exists, please reply if you have anything to add.
+        Thank you for filling out a feature request for Canis! Please be as detailed as possible so that we can consider and review the request easier.
+        We ask that you search all the issues to avoid a duplicate feature request. If one already exists, please reply if you have anything to add.
         Before requesting a new feature, please make sure you are using the latest version and that the feature you are requesting is not already in Canis.
 
   - type: textarea

--- a/.github/ISSUE_TEMPLATES/feature-request.yml
+++ b/.github/ISSUE_TEMPLATES/feature-request.yml
@@ -1,0 +1,45 @@
+name: Feature Request
+description: Suggest an idea for Canis
+title: "[Feature Request]: "
+labels: [ "status: needs triage", "type: feature" ]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thank you for filling out a feature request for Canis! Please be as detailed as possible so that we may consider and review the request easier.
+        We ask that you search all the issues to avoid a duplicate feature request. If one exists, please reply if you have anything to add.
+        Before requesting a new feature, please make sure you are using the latest version and that the feature you are requesting is not already in Canis.
+
+  - type: textarea
+    attributes:
+      label: Is your feature request related to a problem?
+      description: Please give some context for this request. Why do you want it added?
+    validations:
+      required: true
+
+  - type: textarea
+    attributes:
+      label: Describe the solution you'd like.
+      description: A clear and concise description of what you want.
+    validations:
+      required: true
+
+  - type: textarea
+    attributes:
+      label: Describe alternatives you've considered.
+      description: List any alternatives you might have tried to get the feature you want.
+    validations:
+      required: true
+
+  - type: textarea
+    attributes:
+      label: Other
+      description: Add any other context or screenshots about the feature request below.
+    validations:
+      required: false
+
+  - type: markdown
+    attributes:
+      value: |
+        Before submitting this feature request, please search our issue tracker to ensure your feature has not
+        already been requested.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -26,7 +26,7 @@ SOFTWARE.
 
 When creating a pull request, it is essential to provide a clear and concise description of the changes being proposed.
 This description serves as a communication tool to inform the maintainers about the intended modifications. If the pull
-request addresses a bug or resolves a feature request, it is important to link to the corresponding issue for context.
+request addresses a bug or or implements a feature request, it is important to link to the corresponding issue for context.
 Additionally, the description should outline the rationale behind the changes, any relevant implementation details, and
 potential impacts on existing functionality. By including this information, you facilitate a smoother review process and
 help maintainers understand the significance of the proposed changes.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,57 @@
+<!--
+MIT License
+
+Copyright (c) 2022 Marketing Pipeline
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+-->
+
+## Proposed changes
+
+When creating a pull request, it is essential to provide a clear and concise description of the changes being proposed.
+This description serves as a communication tool to inform the maintainers about the intended modifications. If the pull
+request addresses a bug or resolves a feature request, it is important to link to the corresponding issue for context.
+Additionally, the description should outline the rationale behind the changes, any relevant implementation details, and
+potential impacts on existing functionality. By including this information, you facilitate a smoother review process and
+help maintainers understand the significance of the proposed changes.
+
+## Types of changes
+
+What types of changes does your code introduce to this project?
+_Put an `x` in the boxes that apply_
+
+- [ ] Bugfix (non-breaking change which fixes an issue)
+- [ ] New feature (non-breaking change which adds functionality)
+- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
+- [ ] Documentation Update (if none of the other choices apply)
+
+## Checklist
+
+_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
+them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before
+merging your code._
+
+- [ ] I have read the CONTRIBUTING.md
+- [ ] I have added tests that prove my fix is effective or that my feature works
+- [ ] I have added necessary documentation (if appropriate)
+
+## Further comments
+
+If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you
+did and what alternatives you considered, etc...

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -26,7 +26,7 @@ SOFTWARE.
 
 When creating a pull request, it is essential to provide a clear and concise description of the changes being proposed.
 This description serves as a communication tool to inform the maintainers about the intended modifications. If the pull
-request addresses a bug or or implements a feature request, it is important to link to the corresponding issue for context.
+request addresses a bug or implements a feature request, it is important to link to the corresponding issue for context.
 Additionally, the description should outline the rationale behind the changes, any relevant implementation details, and
 potential impacts on existing functionality. By including this information, you facilitate a smoother review process and
 help maintainers understand the significance of the proposed changes.


### PR DESCRIPTION
When users want to create an issue or pull request, it’s often unclear what information to include or which details are necessary. This pull request introduces templates designed to guide users through the process and help them provide the required information.