### PR TITLE
Migrate to Minestom

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![license](https://img.shields.io/github/license/theEvilReaper/Canis?style=for-the-badge&color=b22234c)](../LICENSE)
 
-The fundamental objective of this project is to develop multiple implementations of `BlockHandler` for the Microtus
+The fundamental goal of this project is to develop multiple implementations of `BlockHandler` for the Microtus
 project, which is built on the Minestom framework. The specific functionalities provided by the pre-implemented handlers
 are contingent upon the requirements of the application. For instance, one implementation may permit only read access to
 block data, while another may allow for both reading and modifying this data. It is important to note that this project
@@ -10,8 +10,8 @@ does not aim to replicate the vanilla mechanics of Minecraft; rather, it serves 
 reading from blocks, particularly in the context of mini-games.
 
 > [!IMPORTANT]
-> Due to other projects taking priority, this project may look like it not being maintained.
-> However every pull request is welcome to enhance the functionality of this project.
+> Due to other projects taking priority, this project may look like it is not being maintained.
+> However, every pull request is welcome to enhance the functionality of this project.
 
 ## Usage
 
@@ -26,7 +26,7 @@ repositories {
 }
 
 dependencies {
-    implementation("com.github.theEvilReaper:Canis:master-SNAPSHOT")
+    implementation("net.theevilreaper:canis:<version>
 }
 ```
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -3,7 +3,7 @@ plugins {
     `maven-publish`
 }
 
-group = "net.theevilreaper.canis"
+group = "net.theevilreaper"
 version = "1.0.0-SNAPSHOT"
 
 java {

--- a/jitpack.yml
+++ b/jitpack.yml
@@ -1,8 +1,8 @@
 before_install:
   - source "$HOME/.sdkman/bin/sdkman-init.sh"
   - sdk update
-  - sdk install java 17-open
-  - sdk use java 17-open
+  - sdk install java 21-open
+  - sdk use java 21-open
 install:
   - ./gradlew clean build publishToMavenLocal
 

--- a/renovate.json
+++ b/renovate.json
@@ -1,25 +1,24 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
-    "config:base",
-    ":semanticCommitsDisabled"
+    "config:recommended"
   ],
-  "baseBranches": [
-    "develop"
+  "labels": [
+    "renovate"
   ],
-  "labels": ["Renovate"],
-  "rebaseWhen": "conflicted",
   "packageRules": [
     {
-      "matchUpdateTypes": [
-        "patch"
-      ],
+      "matchPackageNames": ["net.minestom:minestom"],
+      "versioning": "regex:^(?<major>\\d{4})\\.(?<minor>\\d{2})\\.(?<patch>\\d{2})(?<prerelease>[a-zA-Z]?)-(?<build>[A-Za-z0-9._]+)$"
+    },
+    {
+      "matchUpdateTypes": ["major", "minor", "patch"],
       "automerge": true
     }
   ],
   "vulnerabilityAlerts": {
     "labels": [
-      "Component::security"
+      "security"
     ],
     "automerge": true
   }

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -3,10 +3,11 @@ rootProject.name = "Canis"
 dependencyResolutionManagement {
     versionCatalogs {
         create("libs") {
-            version("microtus", "1.5.1")
+            version("minestom", "2025.07.04-1.21.5")
             version("junit", "5.13.3")
-            library("minestom", "net.onelitefeather.microtus", "Microtus").versionRef("microtus")
-            library("minestom-test", "net.onelitefeather.microtus.testing", "testing").versionRef("microtus")
+
+            library("minestom","net.minestom", "minestom").versionRef("minestom")
+            library("minestom-test", "net.minestom", "testing").version("minestom")
             library("junit-jupiter", "org.junit.jupiter", "junit-jupiter").versionRef("junit")
             library("junit-jupiter-engine", "org.junit.jupiter", "junit-jupiter-engine").versionRef("junit")
         }

--- a/src/main/java/net/theevilreaper/canis/BannerHandler.java
+++ b/src/main/java/net/theevilreaper/canis/BannerHandler.java
@@ -6,7 +6,6 @@ import net.minestom.server.tag.Tag;
 import net.minestom.server.tag.TagReadable;
 import net.minestom.server.tag.TagSerializer;
 import net.minestom.server.tag.TagWritable;
-import net.minestom.server.utils.NamespaceID;
 import net.theevilreaper.canis.banner.BannerPattern;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -16,13 +15,14 @@ import java.util.List;
 
 /**
  * Implementation of a {@link BlockHandler} which reads the nbt tags for a banner.
+ *
  * @author theEvilReaper
- * @version 1.0.0
+ * @version 1.1.0
  * @since 1.0.0
  **/
 public class BannerHandler implements BlockHandler {
 
-    private static final NamespaceID namespaceID = NamespaceID.from(Key.key("minecraft:banner"));
+    private static final Key BANNER_KEY = Key.key("minecraft:banner");
 
     /**
      * Custom implementation of a {@link TagSerializer} which reads the Patterns tag from a banner.
@@ -49,6 +49,7 @@ public class BannerHandler implements BlockHandler {
 
     /**
      * Returns all tags which are needed for the block.
+     *
      * @return the list with the tags
      */
     @Override
@@ -56,12 +57,8 @@ public class BannerHandler implements BlockHandler {
         return TAG_LIST;
     }
 
-    /**
-     * Returns the {@link NamespaceID} for the block.
-     * @return the given namespace
-     */
     @Override
-    public @NotNull NamespaceID getNamespaceId() {
-        return namespaceID;
+    public @NotNull Key getKey() {
+        return BANNER_KEY;
     }
 }

--- a/src/main/java/net/theevilreaper/canis/BeaconHandler.java
+++ b/src/main/java/net/theevilreaper/canis/BeaconHandler.java
@@ -1,8 +1,8 @@
 package net.theevilreaper.canis;
 
+import net.kyori.adventure.key.Key;
 import net.minestom.server.instance.block.BlockHandler;
 import net.minestom.server.tag.Tag;
-import net.minestom.server.utils.NamespaceID;
 import org.jetbrains.annotations.NotNull;
 
 import java.util.Collection;
@@ -10,13 +10,14 @@ import java.util.List;
 
 /**
  * Implementation of a {@link BlockHandler} which reads the nbt tags for a beacon.
+ *
  * @author theEvilReaper
- * @version 1.0.0
+ * @version 1.1.0
  * @since 1.0.0
  **/
 public class BeaconHandler implements BlockHandler {
 
-    private static final NamespaceID BEACON_TAG = NamespaceID.from("minecraft:beacon");
+    private static final Key BEACON_TAG = Key.key("minecraft:beacon");
 
     private static final List<Tag<?>> BEACON_TAGS = List.of(
             Tag.String("CustomName"),
@@ -27,7 +28,8 @@ public class BeaconHandler implements BlockHandler {
     );
 
     /**
-     * Returns all tags which are needed for the block.
+     * Returns all tags that are needed for the block.
+     *
      * @return the list with the tags
      */
     @Override
@@ -35,12 +37,8 @@ public class BeaconHandler implements BlockHandler {
         return BEACON_TAGS;
     }
 
-    /**
-     * Returns the {@link NamespaceID} for the block.
-     * @return the given namespace
-     */
     @Override
-    public @NotNull NamespaceID getNamespaceId() {
+    public @NotNull Key getKey() {
         return BEACON_TAG;
     }
 }

--- a/src/main/java/net/theevilreaper/canis/CandleHandler.java
+++ b/src/main/java/net/theevilreaper/canis/CandleHandler.java
@@ -1,8 +1,8 @@
 package net.theevilreaper.canis;
 
+import net.kyori.adventure.key.Key;
 import net.minestom.server.instance.block.BlockHandler;
 import net.minestom.server.tag.Tag;
-import net.minestom.server.utils.NamespaceID;
 import org.jetbrains.annotations.NotNull;
 
 import java.util.Collection;
@@ -11,13 +11,14 @@ import java.util.List;
 /**
  * Implementation of a {@link BlockHandler} which reads the nbt tags for a candle.
  * See <a href="https://minecraft.fandom.com/wiki/Candle">...</a>
+ *
  * @author theEvilReaper
- * @version 1.0.0
+ * @version 1.1.0
  * @since 1.0.0
  **/
 public class CandleHandler implements BlockHandler {
 
-    private static final NamespaceID CANDLE_KEY = NamespaceID.from("minecraft:candle");
+    private static final Key CANDLE_KEY = Key.key("minecraft:candle");
 
     private static final List<Tag<?>> KEYS = List.of(
             Tag.Integer("candles").defaultValue(1),
@@ -27,6 +28,7 @@ public class CandleHandler implements BlockHandler {
 
     /**
      * Returns all tags which are needed for the block.
+     *
      * @return the list with the tags
      */
     @Override
@@ -34,12 +36,9 @@ public class CandleHandler implements BlockHandler {
         return KEYS;
     }
 
-    /**
-     * Returns the {@link NamespaceID} for the block.
-     * @return the given namespace
-     */
+
     @Override
-    public @NotNull NamespaceID getNamespaceId() {
+    public @NotNull Key getKey() {
         return CANDLE_KEY;
     }
 }

--- a/src/main/java/net/theevilreaper/canis/SignHandler.java
+++ b/src/main/java/net/theevilreaper/canis/SignHandler.java
@@ -1,8 +1,8 @@
 package net.theevilreaper.canis;
 
+import net.kyori.adventure.key.Key;
 import net.minestom.server.instance.block.BlockHandler;
 import net.minestom.server.tag.Tag;
-import net.minestom.server.utils.NamespaceID;
 import org.jetbrains.annotations.NotNull;
 
 import java.util.Collection;
@@ -10,13 +10,14 @@ import java.util.List;
 
 /**
  * Implementation of a {@link BlockHandler} which reads the nbt tags for a sign.
+ *
  * @author theEvilReaper
- * @version 1.0.0
+ * @version 1.1.0
  * @since 1.0.0
  **/
 public class SignHandler implements BlockHandler {
 
-    private static final NamespaceID SIGN = NamespaceID.from("minecraft:sign");
+    private static final Key SIGN_KEY = Key.key("minecraft:sign");
 
     private static final List<Tag<?>> SIGN_TAGS = List.of(
             Tag.Byte("GlowingText"),
@@ -29,6 +30,7 @@ public class SignHandler implements BlockHandler {
 
     /**
      * Returns all tags which are needed for the block.
+     *
      * @return the list with the tags
      */
     @Override
@@ -36,12 +38,8 @@ public class SignHandler implements BlockHandler {
         return SIGN_TAGS;
     }
 
-    /**
-     * Returns the {@link NamespaceID} for the block.
-     * @return the given namespace
-     */
     @Override
-    public @NotNull NamespaceID getNamespaceId() {
-        return SIGN;
+    public @NotNull Key getKey() {
+        return SIGN_KEY;
     }
 }

--- a/src/main/java/net/theevilreaper/canis/SkullHandler.java
+++ b/src/main/java/net/theevilreaper/canis/SkullHandler.java
@@ -3,7 +3,6 @@ package net.theevilreaper.canis;
 import net.kyori.adventure.key.Key;
 import net.minestom.server.instance.block.BlockHandler;
 import net.minestom.server.tag.Tag;
-import net.minestom.server.utils.NamespaceID;
 import org.jetbrains.annotations.NotNull;
 
 import java.util.Collection;
@@ -11,13 +10,14 @@ import java.util.List;
 
 /**
  * Implementation of a {@link BlockHandler} which reads the nbt tags for a skull.
+ *
  * @author theEvilReaper
- * @version 1.0.0
+ * @version 1.1.0
  * @since 1.0.0
  **/
 public class SkullHandler implements BlockHandler {
 
-    private static final NamespaceID namespaceID = NamespaceID.from(Key.key("minecraft:skull"));
+    private static final Key SKULL_KEY = Key.key("minecraft:skull");
 
     private static final List<Tag<?>> TAG_LIST = List.of(
             Tag.String("custom_name"),
@@ -26,20 +26,17 @@ public class SkullHandler implements BlockHandler {
     );
 
     /**
-     * Returns all tags which are needed for the block.
+     * Returns all tags that are needed for the block.
+     *
      * @return the list with the tags
      */
     @Override
     public @NotNull Collection<Tag<?>> getBlockEntityTags() {
-       return TAG_LIST;
+        return TAG_LIST;
     }
 
-    /**
-     * Returns the {@link NamespaceID} for the block.
-     * @return the given namespace
-     */
     @Override
-    public @NotNull NamespaceID getNamespaceId() {
-        return namespaceID;
+    public @NotNull Key getKey() {
+        return SKULL_KEY;
     }
 }


### PR DESCRIPTION
The project previously relied on the Microtus fork, which is currently no longer maintained due to several reasons. This pull request updates the project to use Minestom directly instead of the outdated fork. Additionally, the handler implementation has been adapted to the updated structure.

> ⚠️ **Note:** Due to limited time and other priorities, this project still doesn't receive regular updates from my side.  
> If anyone is willing to fix or improve the `BlockHandler` implementations, such pull requests are very welcome.  
> I hope to return to this project in the near future.

